### PR TITLE
Fixed a typo causing a LUA error

### DIFF
--- a/EndRoundMusic.lua
+++ b/EndRoundMusic.lua
@@ -393,7 +393,7 @@ if ( CLIENT ) then
         sound.PlayURL( url, "", function( station )
 			if station and IsValid( station ) then
 				station:Play()
-				LocalPlayer().channel = statio
+				LocalPlayer().channel = station
 				LocalPlayer().channel:SetVolume(volume)
 			end
         end )


### PR DESCRIPTION
I tried your volume modified module but it caused a LUA error even though the sounds played. This fixes that LUA error